### PR TITLE
Nicer print output

### DIFF
--- a/actions/paper
+++ b/actions/paper
@@ -28,7 +28,7 @@ get_tasks_raw(){
 		return 1
 	fi
 
-	cat "$src"
+	/usr/bin/todo.sh -p list
 }
 
 get_tasks_markdown(){


### PR DESCRIPTION
Normally, `todo.sh paper` prints unpadded task number (1, 2, ... 10); using `todo.sh -p list` will use padded numbers (01, 02, ... 10).